### PR TITLE
feat: DAG-L1-C 服务层实现与测试 (#564)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,17 @@ Workflows use repository variable `NIUMA_TEST_RUNNER` when provided, otherwise f
 
 - For `stub` mode, default GitHub-hosted runner is enough.
 - For `codex` mode, set `NIUMA_TEST_RUNNER` to your self-hosted runner label where `codex` is installed.
+
+## DAG Service Fixture
+
+Issue `#564` introduces a lightweight DAG service fixture:
+
+- Foundation layer (`A`): `lib/dag_l0_a_foundation.sh`
+- Service layer (`C`): `lib/dag_l1_c_service.sh`
+
+Run tests:
+
+```bash
+bash tests/dag_l1_c_service_unit_test.sh
+bash tests/dag_l1_c_service_bdd_test.sh
+```

--- a/lib/dag_l0_a_foundation.sh
+++ b/lib/dag_l0_a_foundation.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# 统一状态值，避免服务层处理大小写和空白细节。
+dag_a_normalize_state() {
+  local state="${1:-UNKNOWN}"
+
+  # 去掉首尾空白。
+  state="${state#"${state%%[![:space:]]*}"}"
+  state="${state%"${state##*[![:space:]]}"}"
+
+  if [[ -z "$state" ]]; then
+    echo "UNKNOWN"
+    return 0
+  fi
+
+  echo "${state^^}"
+}
+
+# 判断依赖是否处于 CLOSED，作为服务层的基础判定能力。
+dag_a_is_closed_state() {
+  [[ "$(dag_a_normalize_state "${1:-}")" == "CLOSED" ]]
+}
+
+# 从 issue 正文中提取 blocked-by 依赖编号，按出现顺序去重输出。
+dag_a_extract_blocked_by_ids() {
+  local issue_body="${1:-}"
+  local line raw token dep_id
+  local deps=()
+  declare -A seen=()
+
+  while IFS= read -r line; do
+    if [[ "$line" =~ blocked-by:[[:space:]]*(.*)$ ]]; then
+      raw="${BASH_REMATCH[1]}"
+      raw="${raw//,/ }"
+
+      for token in $raw; do
+        if [[ "$token" =~ ^#?([0-9]+)$ ]]; then
+          dep_id="${BASH_REMATCH[1]}"
+        elif [[ "$token" =~ ^#?([0-9]+)[^0-9].*$ ]]; then
+          dep_id="${BASH_REMATCH[1]}"
+        else
+          continue
+        fi
+
+        if [[ -z "${seen[$dep_id]+x}" ]]; then
+          seen[$dep_id]=1
+          deps+=("$dep_id")
+        fi
+      done
+    fi
+  done <<< "$issue_body"
+
+  if (( ${#deps[@]} > 0 )); then
+    printf '%s\n' "${deps[@]}"
+  fi
+}

--- a/lib/dag_l1_c_service.sh
+++ b/lib/dag_l1_c_service.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if ! declare -F dag_a_extract_blocked_by_ids >/dev/null 2>&1; then
+  # shellcheck source=lib/dag_l0_a_foundation.sh
+  source "$SCRIPT_DIR/dag_l0_a_foundation.sh"
+fi
+
+# 根据 blocked-by 依赖状态给出服务层可执行性判定。
+dag_c_evaluate_issue_readiness() {
+  local issue_number="${1:-}"
+  local issue_body="${2:-}"
+  local resolver_cmd="${3:-}"
+
+  if [[ -z "$issue_number" || -z "$resolver_cmd" ]]; then
+    echo "ERROR|message=missing required arguments(issue_number,resolver_cmd)"
+    return 2
+  fi
+
+  if ! declare -F "$resolver_cmd" >/dev/null 2>&1 && ! command -v "$resolver_cmd" >/dev/null 2>&1; then
+    echo "ERROR|issue=$issue_number|message=resolver not found: $resolver_cmd"
+    return 2
+  fi
+
+  local dep_ids=()
+  mapfile -t dep_ids < <(dag_a_extract_blocked_by_ids "$issue_body")
+
+  if (( ${#dep_ids[@]} == 0 )); then
+    echo "READY|issue=$issue_number|dependencies=none"
+    return 0
+  fi
+
+  local unresolved=()
+  local dep dep_state
+
+  for dep in "${dep_ids[@]}"; do
+    dep_state="$("$resolver_cmd" "$dep")"
+    dep_state="$(dag_a_normalize_state "$dep_state")"
+
+    if ! dag_a_is_closed_state "$dep_state"; then
+      unresolved+=("#$dep:$dep_state")
+    fi
+  done
+
+  local dep_summary=""
+  for dep in "${dep_ids[@]}"; do
+    if [[ -n "$dep_summary" ]]; then
+      dep_summary+=", "
+    fi
+    dep_summary+="#$dep"
+  done
+
+  if (( ${#unresolved[@]} == 0 )); then
+    echo "READY|issue=$issue_number|dependencies=$dep_summary"
+    return 0
+  fi
+
+  local unresolved_summary=""
+  local item
+  for item in "${unresolved[@]}"; do
+    if [[ -n "$unresolved_summary" ]]; then
+      unresolved_summary+=", "
+    fi
+    unresolved_summary+="$item"
+  done
+
+  echo "BLOCKED|issue=$issue_number|waiting=$unresolved_summary"
+  return 1
+}

--- a/test-dag-l1-c-564.md
+++ b/test-dag-l1-c-564.md
@@ -1,0 +1,21 @@
+# DAG-L1-C 服务层测试场景（#564）
+
+## 场景 1：依赖已满足时放行
+- 输入：issue `#564` body 包含 `blocked-by: #562`，依赖查询结果 `#562 -> CLOSED`
+- 预期输出：`dag_c_evaluate_issue_readiness` 返回码 `0`，输出包含 `READY|issue=564`
+
+## 场景 2：存在未满足依赖时阻塞
+- 输入：issue `#565` body 包含 `blocked-by: #562, #563`，依赖查询结果 `#562 -> CLOSED`、`#563 -> OPEN`
+- 预期输出：返回码 `1`，输出包含 `BLOCKED|issue=565` 且等待项包含 `#563:OPEN`
+
+## 场景 3：无依赖声明时默认可执行
+- 输入：issue body 不包含 `blocked-by`
+- 预期输出：返回码 `0`，输出包含 `dependencies=none`
+
+## 场景 4：边界条件 - 重复依赖去重
+- 输入：`blocked-by: #562, #562, #563`
+- 预期输出：依赖解析去重，不重复统计 `#562`；当 `#563` 为 `OPEN` 时仍返回 `BLOCKED`
+
+## 场景 5：边界条件 - resolver 缺失
+- 输入：调用服务层时传入不存在的 resolver
+- 预期输出：返回码 `2`，输出包含 `resolver not found`

--- a/tests/dag_l1_c_service_bdd_test.sh
+++ b/tests/dag_l1_c_service_bdd_test.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# shellcheck source=tests/test_helpers.sh
+source "$ROOT_DIR/tests/test_helpers.sh"
+# shellcheck source=lib/dag_l1_c_service.sh
+source "$ROOT_DIR/lib/dag_l1_c_service.sh"
+
+fake_issue_state_resolver() {
+  case "$1" in
+    562) echo "CLOSED" ;;
+    563) echo "OPEN" ;;
+    *) echo "UNKNOWN" ;;
+  esac
+}
+
+# 场景 1：#564 依赖 #562，且 #562 已关闭，服务层应允许执行。
+issue_564_body=$'L1 节点，等 A 完成后执行。\n\nblocked-by: #562'
+run_and_capture output status dag_c_evaluate_issue_readiness 564 "$issue_564_body" fake_issue_state_resolver
+assert_eq "0" "$status" "场景1失败：#562 CLOSED 时 #564 应 READY"
+assert_contains "$output" "READY|issue=564" "场景1失败：输出应为 READY"
+
+# 场景 2：多依赖中存在 OPEN，服务层应返回阻塞并列出等待项。
+issue_multi_body=$'L1 节点，依赖 A+B。\n\nblocked-by: #562, #563'
+run_and_capture output status dag_c_evaluate_issue_readiness 565 "$issue_multi_body" fake_issue_state_resolver
+assert_eq "1" "$status" "场景2失败：存在 OPEN 依赖时应 BLOCKED"
+assert_contains "$output" "BLOCKED|issue=565" "场景2失败：输出应为 BLOCKED"
+assert_contains "$output" "#563:OPEN" "场景2失败：应标记 OPEN 依赖"
+
+# 场景 3：blocked-by 重复编号应被去重，避免误判和重复等待项。
+issue_duplicate_body=$'blocked-by: #562, #562, #563'
+run_and_capture output status dag_c_evaluate_issue_readiness 566 "$issue_duplicate_body" fake_issue_state_resolver
+assert_eq "1" "$status" "场景3失败：存在 #563 OPEN 时仍应 BLOCKED"
+assert_contains "$output" "waiting=#563:OPEN" "场景3失败：去重后仅应保留真实阻塞项"
+
+echo "PASS: dag_l1_c_service_bdd_test"

--- a/tests/dag_l1_c_service_unit_test.sh
+++ b/tests/dag_l1_c_service_unit_test.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# shellcheck source=tests/test_helpers.sh
+source "$ROOT_DIR/tests/test_helpers.sh"
+# shellcheck source=lib/dag_l1_c_service.sh
+source "$ROOT_DIR/lib/dag_l1_c_service.sh"
+
+mock_resolver_all_closed() {
+  echo "CLOSED"
+}
+
+mock_resolver_mixed() {
+  case "$1" in
+    562) echo "OPEN" ;;
+    *) echo "CLOSED" ;;
+  esac
+}
+
+issue_body_single_dep=$'L1 节点，等 A 完成后执行。\n\nblocked-by: #562'
+issue_body_multi_dep=$'blocked-by: #562, #700'
+
+output=""
+status=""
+
+run_and_capture output status dag_c_evaluate_issue_readiness 564 "$issue_body_single_dep" mock_resolver_all_closed
+assert_eq "0" "$status" "全部依赖关闭时应返回成功状态"
+assert_contains "$output" "READY|issue=564" "全部依赖关闭时应返回 READY"
+assert_contains "$output" "dependencies=#562" "应包含依赖摘要"
+
+run_and_capture output status dag_c_evaluate_issue_readiness 564 "$issue_body_multi_dep" mock_resolver_mixed
+assert_eq "1" "$status" "存在未关闭依赖时应返回阻塞状态"
+assert_contains "$output" "BLOCKED|issue=564" "未满足依赖时应返回 BLOCKED"
+assert_contains "$output" "#562:OPEN" "阻塞信息应包含未关闭依赖"
+
+run_and_capture output status dag_c_evaluate_issue_readiness 564 "" mock_resolver_all_closed
+assert_eq "0" "$status" "无 blocked-by 时应视为可执行"
+assert_contains "$output" "dependencies=none" "无依赖时应标记 none"
+
+run_and_capture output status dag_c_evaluate_issue_readiness 564 "$issue_body_single_dep" missing_resolver_for_test
+assert_eq "2" "$status" "resolver 缺失时应返回参数错误"
+assert_contains "$output" "resolver not found" "错误信息应提示 resolver 不存在"
+
+echo "PASS: dag_l1_c_service_unit_test"

--- a/tests/test_helpers.sh
+++ b/tests/test_helpers.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+assert_eq() {
+  local expected="${1:-}"
+  local actual="${2:-}"
+  local message="${3:-assert_eq failed}"
+
+  if [[ "$expected" != "$actual" ]]; then
+    echo "FAIL: $message"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+    return 1
+  fi
+}
+
+assert_contains() {
+  local text="${1:-}"
+  local pattern="${2:-}"
+  local message="${3:-assert_contains failed}"
+
+  if [[ "$text" != *"$pattern"* ]]; then
+    echo "FAIL: $message"
+    echo "  text:    $text"
+    echo "  pattern: $pattern"
+    return 1
+  fi
+}
+
+run_and_capture() {
+  local output_var="${1:?missing output var name}"
+  local status_var="${2:?missing status var name}"
+  shift 2
+
+  local cmd_output cmd_status
+  set +e
+  cmd_output="$("$@")"
+  cmd_status=$?
+  set -e
+
+  printf -v "$output_var" '%s' "$cmd_output"
+  printf -v "$status_var" '%s' "$cmd_status"
+}


### PR DESCRIPTION
## Summary
- add foundation helpers in `lib/dag_l0_a_foundation.sh` to parse `blocked-by` dependencies and normalize issue states
- add service-layer evaluator in `lib/dag_l1_c_service.sh` to return `READY`/`BLOCKED` decisions for DAG issues
- add unit + BDD-style integration tests under `tests/` and document explicit test scenarios in `test-dag-l1-c-564.md`
- update README with DAG service fixture usage

## Test plan
- bash tests/dag_l1_c_service_unit_test.sh
- bash tests/dag_l1_c_service_bdd_test.sh

Closes #564
