### PR TITLE
feat: DAG-L1-D 集成层实现与测试 (#565)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,18 @@ Workflows use repository variable `NIUMA_TEST_RUNNER` when provided, otherwise f
 
 - For `stub` mode, default GitHub-hosted runner is enough.
 - For `codex` mode, set `NIUMA_TEST_RUNNER` to your self-hosted runner label where `codex` is installed.
+
+## DAG Integration Fixture
+
+Issue `#565` introduces a lightweight DAG integration fixture:
+
+- Foundation layer (`A`): `lib/dag_l0_a_foundation.sh`
+- Tooling layer (`B`): `lib/dag_l0_b_tooling.sh`
+- Integration layer (`D`): `lib/dag_l1_d_integration.sh`
+
+Run tests:
+
+```bash
+bash tests/dag_l1_d_integration_unit_test.sh
+bash tests/dag_l1_d_integration_bdd_test.sh
+```

--- a/lib/dag_l0_a_foundation.sh
+++ b/lib/dag_l0_a_foundation.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# 统一状态值，避免后续层处理大小写和空白细节。
+dag_a_normalize_state() {
+  local state="${1:-UNKNOWN}"
+
+  # 去掉首尾空白。
+  state="${state#"${state%%[![:space:]]*}"}"
+  state="${state%"${state##*[![:space:]]}"}"
+
+  if [[ -z "$state" ]]; then
+    echo "UNKNOWN"
+    return 0
+  fi
+
+  echo "${state^^}"
+}
+
+# 判断依赖是否已关闭。
+dag_a_is_closed_state() {
+  [[ "$(dag_a_normalize_state "${1:-}")" == "CLOSED" ]]
+}
+
+# 从 issue 正文提取 blocked-by 依赖编号，并按出现顺序去重。
+dag_a_extract_blocked_by_ids() {
+  local issue_body="${1:-}"
+  local line raw token dep_id
+  local deps=()
+  declare -A seen=()
+
+  while IFS= read -r line; do
+    if [[ "$line" =~ blocked-by:[[:space:]]*(.*)$ ]]; then
+      raw="${BASH_REMATCH[1]}"
+      raw="${raw//,/ }"
+
+      for token in $raw; do
+        if [[ "$token" =~ ^#?([0-9]+)$ ]]; then
+          dep_id="${BASH_REMATCH[1]}"
+        elif [[ "$token" =~ ^#?([0-9]+)[^0-9].*$ ]]; then
+          dep_id="${BASH_REMATCH[1]}"
+        else
+          continue
+        fi
+
+        if [[ -z "${seen[$dep_id]+x}" ]]; then
+          seen[$dep_id]=1
+          deps+=("$dep_id")
+        fi
+      done
+    fi
+  done <<< "$issue_body"
+
+  if (( ${#deps[@]} > 0 )); then
+    printf '%s\n' "${deps[@]}"
+  fi
+}

--- a/lib/dag_l0_b_tooling.sh
+++ b/lib/dag_l0_b_tooling.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# 检查 gh CLI 是否可用。
+dag_b_require_gh() {
+  if command -v gh >/dev/null 2>&1; then
+    return 0
+  fi
+
+  echo "ERROR|message=gh cli not found"
+  return 127
+}
+
+# 通过 gh 获取 issue 正文。
+dag_b_fetch_issue_body() {
+  local repo="${1:-}"
+  local issue_number="${2:-}"
+
+  if [[ -z "$repo" || -z "$issue_number" ]]; then
+    echo "ERROR|message=missing required arguments(repo,issue_number)"
+    return 2
+  fi
+
+  dag_b_require_gh || return $?
+
+  gh issue view "$issue_number" \
+    --repo "$repo" \
+    --json body \
+    --jq '.body'
+}
+
+# 通过 gh 获取 issue 状态（OPEN/CLOSED）。
+dag_b_fetch_issue_state() {
+  local repo="${1:-}"
+  local issue_number="${2:-}"
+
+  if [[ -z "$repo" || -z "$issue_number" ]]; then
+    echo "ERROR|message=missing required arguments(repo,issue_number)"
+    return 2
+  fi
+
+  dag_b_require_gh || return $?
+
+  gh issue view "$issue_number" \
+    --repo "$repo" \
+    --json state \
+    --jq '.state'
+}

--- a/lib/dag_l1_d_integration.sh
+++ b/lib/dag_l1_d_integration.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if ! declare -F dag_a_extract_blocked_by_ids >/dev/null 2>&1; then
+  # shellcheck source=lib/dag_l0_a_foundation.sh
+  source "$SCRIPT_DIR/dag_l0_a_foundation.sh"
+fi
+
+if ! declare -F dag_b_fetch_issue_body >/dev/null 2>&1; then
+  # shellcheck source=lib/dag_l0_b_tooling.sh
+  source "$SCRIPT_DIR/dag_l0_b_tooling.sh"
+fi
+
+# 集成层入口：组合 A(解析/规范化) + B(工具调用) 判定 issue 是否可执行。
+dag_d_evaluate_integration_readiness() {
+  local repo="${1:-}"
+  local issue_number="${2:-}"
+  local body_fetcher="${3:-dag_b_fetch_issue_body}"
+  local state_fetcher="${4:-dag_b_fetch_issue_state}"
+
+  if [[ -z "$repo" || -z "$issue_number" ]]; then
+    echo "ERROR|message=missing required arguments(repo,issue_number)"
+    return 2
+  fi
+
+  if ! declare -F "$body_fetcher" >/dev/null 2>&1 && ! command -v "$body_fetcher" >/dev/null 2>&1; then
+    echo "ERROR|issue=$issue_number|message=body fetcher not found: $body_fetcher"
+    return 2
+  fi
+
+  if ! declare -F "$state_fetcher" >/dev/null 2>&1 && ! command -v "$state_fetcher" >/dev/null 2>&1; then
+    echo "ERROR|issue=$issue_number|message=state fetcher not found: $state_fetcher"
+    return 2
+  fi
+
+  local issue_body=""
+  local body_rc=0
+
+  set +e
+  issue_body="$($body_fetcher "$repo" "$issue_number")"
+  body_rc=$?
+  set -e
+
+  if (( body_rc != 0 )); then
+    echo "ERROR|issue=$issue_number|message=failed to fetch issue body via $body_fetcher"
+    return 3
+  fi
+
+  local dep_ids=()
+  mapfile -t dep_ids < <(dag_a_extract_blocked_by_ids "$issue_body")
+
+  if (( ${#dep_ids[@]} == 0 )); then
+    echo "READY|issue=$issue_number|dependencies=none"
+    return 0
+  fi
+
+  local unresolved=()
+  local fetch_errors=()
+  local dep dep_state_raw dep_state state_rc
+
+  for dep in "${dep_ids[@]}"; do
+    set +e
+    dep_state_raw="$($state_fetcher "$repo" "$dep")"
+    state_rc=$?
+    set -e
+
+    if (( state_rc != 0 )); then
+      fetch_errors+=("#$dep")
+      continue
+    fi
+
+    dep_state="$(dag_a_normalize_state "$dep_state_raw")"
+    if ! dag_a_is_closed_state "$dep_state"; then
+      unresolved+=("#$dep:$dep_state")
+    fi
+  done
+
+  if (( ${#fetch_errors[@]} > 0 )); then
+    local error_summary=""
+    local item
+    for item in "${fetch_errors[@]}"; do
+      if [[ -n "$error_summary" ]]; then
+        error_summary+=", "
+      fi
+      error_summary+="$item"
+    done
+
+    echo "ERROR|issue=$issue_number|message=failed to fetch dependency states|failed=$error_summary"
+    return 3
+  fi
+
+  if (( ${#unresolved[@]} == 0 )); then
+    local dep_summary=""
+
+    for dep in "${dep_ids[@]}"; do
+      if [[ -n "$dep_summary" ]]; then
+        dep_summary+=", "
+      fi
+      dep_summary+="#$dep"
+    done
+
+    echo "READY|issue=$issue_number|dependencies=$dep_summary"
+    return 0
+  fi
+
+  local unresolved_summary=""
+  local unresolved_item
+
+  for unresolved_item in "${unresolved[@]}"; do
+    if [[ -n "$unresolved_summary" ]]; then
+      unresolved_summary+=", "
+    fi
+    unresolved_summary+="$unresolved_item"
+  done
+
+  echo "BLOCKED|issue=$issue_number|waiting=$unresolved_summary"
+  return 1
+}

--- a/test-dag-l1-d-565.md
+++ b/test-dag-l1-d-565.md
@@ -1,0 +1,21 @@
+# DAG-L1-D 集成层测试场景（#565）
+
+## 场景 1：A+B 依赖全部关闭时放行
+- 输入：issue `#565` body 为 `blocked-by: #562, #563`，状态查询结果 `#562 -> CLOSED`、`#563 -> CLOSED`
+- 预期输出：`dag_d_evaluate_integration_readiness` 返回码 `0`，输出包含 `READY|issue=565` 与 `dependencies=#562, #563`
+
+## 场景 2：存在未满足依赖时阻塞
+- 输入：issue `#565` body 为 `blocked-by: #562, #563`，状态查询结果 `#562 -> CLOSED`、`#563 -> OPEN`
+- 预期输出：返回码 `1`，输出包含 `BLOCKED|issue=565` 且等待项包含 `#563:OPEN`
+
+## 场景 3：无依赖声明时默认可执行
+- 输入：issue body 不包含 `blocked-by`
+- 预期输出：返回码 `0`，输出包含 `dependencies=none`
+
+## 场景 4：边界条件 - 依赖状态查询失败
+- 输入：issue `#565` 依赖 `#562,#563`，其中 `#563` 状态查询失败
+- 预期输出：返回码 `3`，输出包含 `ERROR|issue=565`，并包含 `failed=#563`
+
+## 场景 5：边界条件 - fetcher 缺失或参数缺失
+- 输入：未传 repo/issue，或传入不存在的 body/state fetcher
+- 预期输出：返回码 `2`，输出包含对应的参数错误信息

--- a/tests/dag_l1_d_integration_bdd_test.sh
+++ b/tests/dag_l1_d_integration_bdd_test.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# shellcheck source=tests/test_helpers.sh
+source "$ROOT_DIR/tests/test_helpers.sh"
+# shellcheck source=lib/dag_l1_d_integration.sh
+source "$ROOT_DIR/lib/dag_l1_d_integration.sh"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+cat > "$TMP_DIR/gh" <<'MOCK_GH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" != "issue" || "${2:-}" != "view" ]]; then
+  echo "unsupported command" >&2
+  exit 10
+fi
+
+issue_number="${3:-}"
+shift 3
+
+repo=""
+json_field=""
+
+while (( $# > 0 )); do
+  case "$1" in
+    --repo)
+      repo="$2"
+      shift 2
+      ;;
+    --json)
+      json_field="$2"
+      shift 2
+      ;;
+    --jq)
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if [[ "$repo" != "biantaishabi2/Cli-niuma-test" ]]; then
+  echo "unexpected repo: $repo" >&2
+  exit 11
+fi
+
+case "$json_field" in
+  body)
+    case "$issue_number" in
+      565)
+        cat <<'BODY'
+L1 节点，等 A 和 B 都完成后执行。
+
+blocked-by: #562, #563
+BODY
+        ;;
+      700)
+        echo "这是一个无依赖 issue"
+        ;;
+      *)
+        echo "unknown issue" >&2
+        exit 12
+        ;;
+    esac
+    ;;
+  state)
+    case "$issue_number" in
+      562)
+        echo "CLOSED"
+        ;;
+      563)
+        if [[ "${MOCK_FAIL_563:-0}" == "1" ]]; then
+          exit 13
+        fi
+        echo "${MOCK_563_STATE:-OPEN}"
+        ;;
+      *)
+        echo "OPEN"
+        ;;
+    esac
+    ;;
+  *)
+    echo "unsupported json field: $json_field" >&2
+    exit 14
+    ;;
+esac
+MOCK_GH
+
+chmod +x "$TMP_DIR/gh"
+PATH="$TMP_DIR:$PATH"
+
+output=""
+status=""
+
+# 场景 1：默认 #563 OPEN，D 层应给出 BLOCKED。
+run_and_capture output status dag_d_evaluate_integration_readiness biantaishabi2/Cli-niuma-test 565
+assert_eq "1" "$status" "场景1失败：存在 OPEN 依赖时应 BLOCKED"
+assert_contains "$output" "BLOCKED|issue=565" "场景1失败：输出应为 BLOCKED"
+assert_contains "$output" "#563:OPEN" "场景1失败：应显示等待 #563"
+
+# 场景 2：切换 #563 CLOSED，D 层应 READY。
+MOCK_563_STATE="CLOSED" run_and_capture output status dag_d_evaluate_integration_readiness biantaishabi2/Cli-niuma-test 565
+assert_eq "0" "$status" "场景2失败：依赖全 CLOSED 时应 READY"
+assert_contains "$output" "READY|issue=565" "场景2失败：输出应为 READY"
+assert_contains "$output" "dependencies=#562, #563" "场景2失败：应输出依赖摘要"
+
+# 场景 3：无 blocked-by 时默认可执行。
+run_and_capture output status dag_d_evaluate_integration_readiness biantaishabi2/Cli-niuma-test 700
+assert_eq "0" "$status" "场景3失败：无依赖应 READY"
+assert_contains "$output" "dependencies=none" "场景3失败：应标记 none"
+
+# 场景 4：依赖状态查询失败时返回 ERROR。
+MOCK_FAIL_563="1" run_and_capture output status dag_d_evaluate_integration_readiness biantaishabi2/Cli-niuma-test 565
+assert_eq "3" "$status" "场景4失败：状态查询失败应 ERROR"
+assert_contains "$output" "ERROR|issue=565" "场景4失败：输出应为 ERROR"
+assert_contains "$output" "failed=#563" "场景4失败：应标识失败依赖"
+
+echo "PASS: dag_l1_d_integration_bdd_test"

--- a/tests/dag_l1_d_integration_unit_test.sh
+++ b/tests/dag_l1_d_integration_unit_test.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# shellcheck source=tests/test_helpers.sh
+source "$ROOT_DIR/tests/test_helpers.sh"
+# shellcheck source=lib/dag_l1_d_integration.sh
+source "$ROOT_DIR/lib/dag_l1_d_integration.sh"
+
+mock_body_with_multi_deps() {
+  cat <<'BODY'
+L1 节点，等 A 和 B 都完成后执行。
+
+blocked-by: #562, #563
+BODY
+}
+
+mock_body_without_deps() {
+  echo "no dependencies declared"
+}
+
+mock_state_all_closed() {
+  echo "CLOSED"
+}
+
+mock_state_mixed() {
+  case "$2" in
+    562) echo "CLOSED" ;;
+    563) echo "OPEN" ;;
+    *) echo "UNKNOWN" ;;
+  esac
+}
+
+mock_state_fail_on_563() {
+  case "$2" in
+    563) return 9 ;;
+    *) echo "CLOSED" ;;
+  esac
+}
+
+mock_body_fetch_fail() {
+  return 5
+}
+
+output=""
+status=""
+
+run_and_capture output status dag_d_evaluate_integration_readiness biantaishabi2/Cli-niuma-test 565 mock_body_with_multi_deps mock_state_all_closed
+assert_eq "0" "$status" "全部依赖关闭时应 READY"
+assert_contains "$output" "READY|issue=565" "全部依赖关闭时应输出 READY"
+assert_contains "$output" "dependencies=#562, #563" "应输出完整依赖摘要"
+
+run_and_capture output status dag_d_evaluate_integration_readiness biantaishabi2/Cli-niuma-test 565 mock_body_with_multi_deps mock_state_mixed
+assert_eq "1" "$status" "存在 OPEN 依赖时应 BLOCKED"
+assert_contains "$output" "BLOCKED|issue=565" "应输出 BLOCKED"
+assert_contains "$output" "#563:OPEN" "应包含未满足依赖"
+
+run_and_capture output status dag_d_evaluate_integration_readiness biantaishabi2/Cli-niuma-test 565 mock_body_without_deps mock_state_all_closed
+assert_eq "0" "$status" "无 blocked-by 时应 READY"
+assert_contains "$output" "dependencies=none" "无依赖时应标记 none"
+
+run_and_capture output status dag_d_evaluate_integration_readiness biantaishabi2/Cli-niuma-test 565 mock_body_with_multi_deps mock_state_fail_on_563
+assert_eq "3" "$status" "依赖状态获取失败时应返回错误"
+assert_contains "$output" "failed to fetch dependency states" "应提示依赖状态获取失败"
+assert_contains "$output" "failed=#563" "应标记失败依赖"
+
+run_and_capture output status dag_d_evaluate_integration_readiness biantaishabi2/Cli-niuma-test 565 mock_body_fetch_fail mock_state_all_closed
+assert_eq "3" "$status" "issue 正文获取失败时应返回错误"
+assert_contains "$output" "failed to fetch issue body" "应提示正文获取失败"
+
+run_and_capture output status dag_d_evaluate_integration_readiness biantaishabi2/Cli-niuma-test 565 missing_body_fetcher mock_state_all_closed
+assert_eq "2" "$status" "body fetcher 缺失应返回参数错误"
+assert_contains "$output" "body fetcher not found" "应提示 fetcher 不存在"
+
+echo "PASS: dag_l1_d_integration_unit_test"

--- a/tests/test_helpers.sh
+++ b/tests/test_helpers.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+assert_eq() {
+  local expected="${1:-}"
+  local actual="${2:-}"
+  local message="${3:-assert_eq failed}"
+
+  if [[ "$expected" != "$actual" ]]; then
+    echo "FAIL: $message"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+    return 1
+  fi
+}
+
+assert_contains() {
+  local text="${1:-}"
+  local pattern="${2:-}"
+  local message="${3:-assert_contains failed}"
+
+  if [[ "$text" != *"$pattern"* ]]; then
+    echo "FAIL: $message"
+    echo "  text:    $text"
+    echo "  pattern: $pattern"
+    return 1
+  fi
+}
+
+run_and_capture() {
+  local output_var="${1:?missing output var name}"
+  local status_var="${2:?missing status var name}"
+  shift 2
+
+  local cmd_output cmd_status
+  set +e
+  cmd_output="$($@)"
+  cmd_status=$?
+  set -e
+
+  printf -v "$output_var" '%s' "$cmd_output"
+  printf -v "$status_var" '%s' "$cmd_status"
+}


### PR DESCRIPTION
## Summary
- add DAG L0 foundation helpers in `lib/dag_l0_a_foundation.sh` for blocked-by parsing and state normalization
- add DAG L0 tooling helpers in `lib/dag_l0_b_tooling.sh` to fetch issue body/state via `gh issue view`
- add DAG L1-D integration evaluator in `lib/dag_l1_d_integration.sh` to combine A+B and return READY/BLOCKED/ERROR decisions
- add unit and BDD tests in `tests/dag_l1_d_integration_unit_test.sh` and `tests/dag_l1_d_integration_bdd_test.sh`
- document explicit test scenarios in `test-dag-l1-d-565.md` and update README usage

## Test plan
- bash tests/dag_l1_d_integration_unit_test.sh
- bash tests/dag_l1_d_integration_bdd_test.sh

Closes #565
